### PR TITLE
Added control to focus on components when the form has some errors

### DIFF
--- a/config/jsvalidation.php
+++ b/config/jsvalidation.php
@@ -13,4 +13,17 @@ return array(
      */
     'form_selector' => 'form',
 
+
+    /**
+     * If you change the focus on detect some error then active
+     * this parameter to move the focus to the first error found.
+     */
+    'focus_on_error' => false,
+
+    /**
+     * Duration time for the animation when We are moving the focus
+     * to the first error, http://api.jquery.com/animate/ for more information.
+     */
+    'duration_animate' => 1000,
+
 );

--- a/resources/views/bootstrap.php
+++ b/resources/views/bootstrap.php
@@ -14,6 +14,19 @@
             errorClass: 'help-block help-block-error', // default input error message class
             focusInvalid: false, // do not focus the last invalid input
             ignore: "",  // validate all fields including form hidden input
+            <?php if(Config::get('jsvalidation.focus_on_error')): ?>
+            invalidHandler: function(form, validator) {
+
+                if (!validator.numberOfInvalids())
+                    return;
+
+                $('html, body').animate({
+                    scrollTop: $(validator.errorList[0].element).offset().top
+                }, <?php echo Config::get('jsvalidation.duration_animate') ?>);
+                $(validator.errorList[0].element).focus();
+
+            },
+            <?php endif; ?>
             errorPlacement: function(error, element) {
                 if (element.attr("type") == "radio") {
                     error.insertAfter(element.parents('div').find('.radio-list'));


### PR DESCRIPTION


Hello:

I fork your repository to add a new feature in your component:

When We are validating the form I want to move the view to the first error and set the focus on the first component on my form.

I added two new parameters on the config to active or not this feature and to control the time of the animate to move the scroll.

Thank you
Samuel