### PR TITLE
Bugfix - Validate PUT methods on remote

### DIFF
--- a/resources/assets/js/jsvalidation.js
+++ b/resources/assets/js/jsvalidation.js
@@ -125,7 +125,7 @@ laravelValidation = {
                 data: data,
                 context: validator.currentForm,
                 url: $(validator.currentForm).attr('action'),
-                type: $(validator.currentForm).attr('method'),
+                type: $(validator.currentForm).find('input[name="_method"]').val() ? $(validator.currentForm).find('input[name="_method"]').val() : $(validator.currentForm).attr('method'),
 
                 beforeSend: function (xhr) {
                     if ($(validator.currentForm).attr('method').toLowerCase() !== 'get' && token) {

--- a/resources/assets/js/jsvalidation.js
+++ b/resources/assets/js/jsvalidation.js
@@ -119,7 +119,7 @@ laravelValidation = {
             data['_jsvalidation']= attribute;
             var formMethod = $(validator.currentForm).attr('method');
             if($(validator.currentForm).find('input[name="_method"]').length) {
-                formMethod = $(validator.currentForm).find('input[name="_method"]');
+                formMethod = $(validator.currentForm).find('input[name="_method"]').val();
             }
 
             $.ajax( $.extend( true, {

--- a/resources/assets/js/jsvalidation.js
+++ b/resources/assets/js/jsvalidation.js
@@ -117,6 +117,10 @@ laravelValidation = {
             data = {};
             data[ element.name ] = value;
             data['_jsvalidation']= attribute;
+            var formMethod = $(validator.currentForm).attr('method');
+            if($(validator.currentForm).find('input[name="_method"]').length) {
+                formMethod = $(validator.currentForm).find('input[name="_method"]');
+            }
 
             $.ajax( $.extend( true, {
                 mode: "abort",
@@ -125,7 +129,7 @@ laravelValidation = {
                 data: data,
                 context: validator.currentForm,
                 url: $(validator.currentForm).attr('action'),
-                type: $(validator.currentForm).find('input[name="_method"]').val() ? $(validator.currentForm).find('input[name="_method"]').val() : $(validator.currentForm).attr('method'),
+                type: formMethod,
 
                 beforeSend: function (xhr) {
                     if ($(validator.currentForm).attr('method').toLowerCase() !== 'get' && token) {


### PR DESCRIPTION
Given the fact that PUT is not a valid method of a form, we need to get the actual method of the route which can be found in html as "_method"