### PR TITLE
Check for hidden _method on form for remote validation

### DIFF
--- a/public/js/jsvalidation.js
+++ b/public/js/jsvalidation.js
@@ -2178,6 +2178,15 @@ laravelValidation = {
             data = {};
             data[ element.name ] = value;
             data['_jsvalidation']= attribute;
+            var hiddenMethod = $(validator.currentForm).find('input[name=_method]').val();
+            if (typeof hiddenMethod != 'undefined')
+            {
+            	var methodToUse = hiddenMethod;
+            }
+            else
+            {
+            	var methodToUse = $(validator.currentForm).attr('method');
+            }
 
             $.ajax( $.extend( true, {
                 mode: "abort",
@@ -2186,7 +2195,7 @@ laravelValidation = {
                 data: data,
                 context: validator.currentForm,
                 url: $(validator.currentForm).attr('action'),
-                type: $(validator.currentForm).attr('method'),
+                type: methodToUse,
 
                 beforeSend: function (xhr) {
                     if ($(validator.currentForm).attr('method').toLowerCase() !== 'get' && token) {


### PR DESCRIPTION
When creating a form in Laravel, the form may have a hidden input with a
name of '_method' to describe the actual method that should be used. The
existing validation was checking the 'METHOD' attribute of the form
element, which is not necessarily correct. Modified code to check for
hidden _method attribute and use that instead if it exists.