### PR TITLE
Allow multiple JsValidator instances

### DIFF
--- a/resources/views/bootstrap.php
+++ b/resources/views/bootstrap.php
@@ -18,10 +18,10 @@
                 $(element).closest('.form-group').addClass('has-error'); // add the Bootstrap error class to the control group
             },
 
-            <?php if (isset($validator['ignore']) && is_string($validator['ignore'])) { ?>
+            <?php if (isset($validator['ignore']) && is_string($validator['ignore'])): ?>
 
             ignore: "<?php echo $validator['ignore']; ?>",
-            <?php } ?>
+            <?php endif; ?>
 
             /*
              // Uncomment this to mark as validated non required fields

--- a/resources/views/bootstrap.php
+++ b/resources/views/bootstrap.php
@@ -18,6 +18,11 @@
                 $(element).closest('.form-group').addClass('has-error'); // add the Bootstrap error class to the control group
             },
 
+            <?php if (isset($validator['ignore']) && is_string($validator['ignore'])) { ?>
+
+            ignore: "<?php echo $validator['ignore']; ?>",
+            <?php } ?>
+
             /*
              // Uncomment this to mark as validated non required fields
              unhighlight: function(element) {

--- a/src/JsValidationServiceProvider.php
+++ b/src/JsValidationServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Proengsoft\JsValidation;
 
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Contracts\Validation\Factory as IlluminateValidationFactory;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
 use Proengsoft\JsValidation;
@@ -40,7 +39,7 @@ class JsValidationServiceProvider extends ServiceProvider
             $view = Config::get('jsvalidation.view');
 
             $manager = new Manager($selector, $view);
-            $validatorFactory = $app->make(IlluminateValidationFactory::class);
+            $validatorFactory = $app->make('Illuminate\Contracts\Validation\Factory');
 
             return new JsValidatorFactory($validatorFactory, $manager, $app);
         });

--- a/src/JsValidationServiceProvider.php
+++ b/src/JsValidationServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Proengsoft\JsValidation;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Validation\Factory as IlluminateValidationFactory;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
 use Proengsoft\JsValidation;
@@ -39,7 +40,7 @@ class JsValidationServiceProvider extends ServiceProvider
             $view = Config::get('jsvalidation.view');
 
             $manager = new Manager($selector, $view);
-            $validatorFactory = $app->make('Illuminate\Contracts\Validation\Factory');
+            $validatorFactory = $app->make(IlluminateValidationFactory::class);
 
             return new JsValidatorFactory($validatorFactory, $manager, $app);
         });

--- a/src/JsValidatorFactory.php
+++ b/src/JsValidatorFactory.php
@@ -144,9 +144,11 @@ class JsValidatorFactory
      */
     protected function jsValidator(Validator $validator, $selector = null)
     {
-        $this->manager->selector($selector);
-        $this->manager->setValidator($validator);
+        $manager = clone $this->manager;
 
-        return $this->manager;
+        $manager->selector($selector);
+        $manager->setValidator($validator);
+
+        return $manager;
     }
 }

--- a/src/JsValidatorFactory.php
+++ b/src/JsValidatorFactory.php
@@ -79,7 +79,7 @@ class JsValidatorFactory
      */
     public function formRequest($formRequest, $selector = null)
     {
-        if (! is_subclass_of($formRequest, FormRequest::class)) {
+        if (! is_subclass_of($formRequest, 'Illuminate\\Foundation\\Http\\FormRequest')) {
             throw new FormRequestArgumentException((string) $formRequest);
         }
 

--- a/src/JsValidatorFactory.php
+++ b/src/JsValidatorFactory.php
@@ -79,7 +79,7 @@ class JsValidatorFactory
      */
     public function formRequest($formRequest, $selector = null)
     {
-        if (! is_subclass_of($formRequest, 'Illuminate\\Foundation\\Http\\FormRequest')) {
+        if (! is_subclass_of($formRequest, FormRequest::class)) {
             throw new FormRequestArgumentException((string) $formRequest);
         }
 
@@ -101,7 +101,7 @@ class JsValidatorFactory
      */
     protected function createFormRequest($class)
     {
-        /**
+        /*
          * @var \Illuminate\Foundation\Http\FormRequest
          * @var $request Request
          */

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -30,6 +30,13 @@ class Manager implements Arrayable
     protected $view;
 
     /**
+     * 'ignore' option for jQuery Validation Plugin
+     *
+     * @var string
+     */
+    protected $ignore;
+
+    /**
      * @param string $selector
      * @param string $view
      */
@@ -115,6 +122,10 @@ class Manager implements Arrayable
         $data = $this->validator->validationData();
         $data['selector'] = $this->selector;
 
+        if (!is_null($this->ignore)) {
+            $data['ignore'] = $this->ignore;
+        }
+
         return $data;
     }
 
@@ -136,6 +147,18 @@ class Manager implements Arrayable
     public function selector($selector)
     {
         $this->selector = is_null($selector) ? $this->selector : $selector;
+
+        return $this;
+    }
+
+    /**
+     * Set the input selector to ignore for validation.
+     * @param string $ignore
+     * @return Manager
+     */
+    public function ignore($ignore)
+    {
+        $this->ignore = $ignore;
 
         return $this;
     }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -30,7 +30,7 @@ class Manager implements Arrayable
     protected $view;
 
     /**
-     * 'ignore' option for jQuery Validation Plugin
+     * 'ignore' option for jQuery Validation Plugin.
      *
      * @var string
      */
@@ -122,7 +122,7 @@ class Manager implements Arrayable
         $data = $this->validator->validationData();
         $data['selector'] = $this->selector;
 
-        if (!is_null($this->ignore)) {
+        if (! is_null($this->ignore)) {
             $data['ignore'] = $this->ignore;
         }
 


### PR DESCRIPTION
* permit multiple validator instances so subsequent calls to `JsValidator::make()` and `JsValidator::formRequest()` don't overwrite the previous selector + validator. Some justification for this implementation can be found at https://github.com/proengsoft/laravel-jsvalidation/issues/87
* add `ignore()` method to the JsValidator facade so a jQuery selector may be defined per-form as this is the typical use case for jQuery Validator's 'ignore' option. Custom non-Bootstrap views may optionally implement this functionality. Example usage:

  ```php
  $jsValidator = JsValidator::make($rules);
  $jsValidator->selector("form[action='" . $action . "']");
  $jsValidator->ignore("[name!='some_hidden_but_required_input']:hidden");
  ```