### PR TITLE
Update JsValidatorFactory.php

### DIFF
--- a/src/JsValidatorFactory.php
+++ b/src/JsValidatorFactory.php
@@ -138,6 +138,7 @@ class JsValidatorFactory
         $formRequest->setUserResolver($request->getUserResolver());
         $formRequest->setRouteResolver($request->getRouteResolver());
         $formRequest->setContainer($this->app);
+        $formRequest->query = $request->query;
 
         return $formRequest;
     }


### PR DESCRIPTION
urls with query parameters like ?foo=bar 

use JsValidator::formRequest to generate rules from my custom form request class

can't use $this->get('foo') in any methods, value always be null

Of course we can use helper function request() event $_GET to make it, but I don't think it's proper way