### PR TITLE
Support 0-indexed arrays for 5.2 validation wildcard rules

### DIFF
--- a/src/Javascript/JavascriptValidator.php
+++ b/src/Javascript/JavascriptValidator.php
@@ -3,8 +3,8 @@
 namespace Proengsoft\JsValidation\Javascript;
 
 use Exception;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\View;
+use Illuminate\Contracts\Support\Arrayable;
 use Proengsoft\JsValidation\Exceptions\PropertyNotFoundException;
 
 class JavascriptValidator implements Arrayable
@@ -136,6 +136,10 @@ class JavascriptValidator implements Arrayable
         $this->validator->setRemote($this->remote);
         $data = $this->validator->validationData();
         $data['selector'] = $this->selector;
+
+        if (! is_null($this->validator->getDelegatedValidator())) {
+            $data['wildcards'] = $this->validator->getDelegatedValidator()->getWildcardRules();
+        }
 
         if (! is_null($this->ignore)) {
             $data['ignore'] = $this->ignore;

--- a/src/Javascript/RuleParser.php
+++ b/src/Javascript/RuleParser.php
@@ -2,8 +2,8 @@
 
 namespace Proengsoft\JsValidation\Javascript;
 
-use Proengsoft\JsValidation\Support\DelegatedValidator;
 use Proengsoft\JsValidation\Support\RuleListTrait;
+use Proengsoft\JsValidation\Support\DelegatedValidator;
 use Proengsoft\JsValidation\Support\UseDelegatedValidatorTrait;
 
 class RuleParser
@@ -161,11 +161,24 @@ class RuleParser
      */
     protected function getAttributeName($attribute)
     {
-        $attributeArray = explode('.', $attribute);
-        if (count($attributeArray) > 1) {
-            return $attributeArray[0].'['.implode('][', array_slice($attributeArray, 1)).']';
+        if (stripos($attribute, '.') === false) {
+            return $attribute;
         }
 
-        return $attribute;
+        $attributes = explode('.', $attribute);
+
+        return $attributes[0].
+            '['.
+            implode(
+                '][',
+                array_map(function ($attribute) {
+                    if ($attribute === '*') {
+                        return '';
+                    }
+
+                    return $attribute;
+                }, array_slice($attributes, 1))
+            ).
+            ']';
     }
 }

--- a/src/Support/DelegatedValidator.php
+++ b/src/Support/DelegatedValidator.php
@@ -8,6 +8,7 @@ use Illuminate\Validation\Validator as BaseValidator;
 class DelegatedValidator
 {
     use AccessProtectedTrait;
+
     /**
      * The Validator resolved instance.
      *
@@ -23,14 +24,23 @@ class DelegatedValidator
     protected $validatorMethod;
 
     /**
+     * Array validation rules with * wildcard matching.
+     *
+     * @var array
+     */
+    protected $wildcardRules;
+
+    /**
      * DelegatedValidator constructor.
      *
      * @param \Illuminate\Validation\Validator $validator
+     * @param array                            $wildcardRules
      */
-    public function __construct(BaseValidator $validator)
+    public function __construct(BaseValidator $validator, array $wildcardRules = [])
     {
         $this->validator = $validator;
         $this->validatorMethod = $this->createProtectedCaller($validator);
+        $this->wildcardRules = $wildcardRules;
     }
 
     /**
@@ -38,6 +48,7 @@ class DelegatedValidator
      *
      * @param string $method
      * @param array $args
+     *
      * @return mixed
      */
     private function callValidator($method, $args = [])
@@ -82,7 +93,17 @@ class DelegatedValidator
      */
     public function getRules()
     {
-        return $this->validator->getRules();
+        return $this->validator->getRules() + $this->wildcardRules;
+    }
+
+    /**
+     * Get the validation rules with '*' wildcard.
+     *
+     * @return array
+     */
+    public function getWildcardRules()
+    {
+        return $this->wildcardRules;
     }
 
     /**

--- a/tests/Javascript/JavascriptValidatorTest.php
+++ b/tests/Javascript/JavascriptValidatorTest.php
@@ -103,6 +103,48 @@ class JavascriptValidatorTest extends \PHPUnit_Framework_TestCase
     }
 
 
+
+    public function  testToArrayWildcards()
+    {
+        $mockHandler = $this->getMockBuilder('\Proengsoft\JsValidation\Javascript\ValidatorHandler')
+            ->disableOriginalConstructor()
+            ->setMethods(['validationData','setRemote','getDelegatedValidator'])
+            ->getMock();
+
+        $mockHandler->expects($this->once())
+            ->method('setRemote')
+            ->with(true)
+            ->willReturn([]);
+
+        $mockHandler->expects($this->once())
+            ->method('validationData')
+            ->with()
+            ->willReturn([]);
+
+        $mockDelegated = $this->getMockBuilder('Proengsoft\JsValidation\Support\DelegatedValidator')
+            ->disableOriginalConstructor()
+            ->setMethods(['getWildcardRules'])
+            ->getMock();
+
+        $mockDelegated->expects($this->once())
+            ->method('getWildcardRules')
+            ->with()
+            ->willReturn(['person.*.email' => ['Required', 'Email']]);
+
+        $mockHandler->expects($this->exactly(2))
+            ->method('getDelegatedValidator')
+            ->with()
+            ->willReturn($mockDelegated);
+
+        $validator = new JavascriptValidator($mockHandler);
+
+        $expected=['selector'=>'form','wildcards' => ['person.*.email' => ['Required', 'Email']]];
+        $viewData=$validator->toArray();
+        $this->assertEquals($expected,$viewData);
+
+    }
+
+
     public function testGet()
     {
         $mockHandler = $this->getMockBuilder('\Proengsoft\JsValidation\Javascript\ValidatorHandler')


### PR DESCRIPTION
## Support Laravel 5.2 `*` for non-keyed PHP array inputs

e.g.,

* Rule `['items.*.name' => 'required']` will validate:
  * DOM selector: `'[name="items\\[\\]\\[name\\]"]'`
  * DOM attribute: `name="items[][name]"`
* Rule `['item_name.*' => 'required']` will validate:
  * DOM selector: `'[name="item_name\\[\\]"]'`
  * DOM attribute: `name="items_name[]"`

Laravel 5.2's `Validator::make()` immediately strips wildcard rules (since JsValidator's instantiation never includes data) so they must be tracked separately in the `DelegatedValidator` class.

## Named PHP array key inputs not yet supported

Unfortunately named associative array keys are not yet supported in JavaScript as:

* The jQuery Validation plugin requires exact form `name=""` attribute values when defining rules and custom messages.
* `$(document).ready()` best-guess attempts to apply rules to `name=""` attributes on the page are made redundant by dynamically-added DOM elements that are the typical use case of wildcard rules.
   * Be it new table rows or Ajax resulting re-renders.

```javascript
function discoverWildcardNames(wildcards) {
    var inputNames = $(':input')
        .map(function (i, el) {
            return el.getAttribute('name');
        })
        .toArray();

    var matches = wildcards
        .map(function (attribute) {
            return attribute
                .split('.')
                .map(function(key, i) {
                    if (i === 0) {
                        return key.replace('[', '\\[');
                    } else if (key === '*') {
                        return '\\[[^\\\\]*\\]';
                    } else {
                        return '\\[' +
                            key.replace('[', '\\[').replace(']', '\\]') +
                            '\\]';
                    }
                })
                .join('');
        })
        .map(function (pattern) {
            return new RegExp('^' + pattern + '$');
        })
        .map(function (regex) {
            return inputNames
                .slice(0)
                .filter(function (name) {
                    return regex.test(name);
                });
        });

    var nameMatches = {};
    for (var i in wildcards) {
        nameMatches[wildcards[i]] = matches[i];
    }

    return nameMatches;
}

// Example array validation from https://laravel.com/docs/5.3/validation#validating-arrays
discoverWildcardNames([
    'person.*.email',
    'person.*.first_name'
]);
```

* New DOM elements `<input>`, `<textarea>`, or `<select>` inserted dynamically to the DOM tree will not be included for form validation.
* The default Bootstrap view would have to be refactored to support such a callback when defining `$().validate({rules: {}})`.

If there's enough demand, I could try such a hack... because it would be a hack.