### PR TITLE
Support for Laravel 5.3.21 and 5.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IDE
 build/
+.idea/
 
 # composer
 vendor

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "illuminate/contracts": "~5.0",
         "illuminate/view": "~5.0",
         "illuminate/config": "~5.0",
-        "illuminate/http": "~5.0"
+        "illuminate/http": "~5.0",
+        "illuminate/translation": "~5.0"
 
     },
     "require-dev": {

--- a/src/Support/DelegatedValidator.php
+++ b/src/Support/DelegatedValidator.php
@@ -34,7 +34,7 @@ class DelegatedValidator
     }
 
     /**
-     * Call validator method
+     * Call validator method.
      *
      * @param string $method
      * @param array $args
@@ -92,7 +92,7 @@ class DelegatedValidator
      */
     public function getFiles()
     {
-        if (method_exists($this->validator,'getFiles')) {
+        if (method_exists($this->validator, 'getFiles')) {
             return $this->validator->getFiles();
         }
 
@@ -108,10 +108,10 @@ class DelegatedValidator
      */
     public function setFiles(array $files)
     {
-        if (method_exists($this->validator,'setFiles')) {
+        if (method_exists($this->validator, 'setFiles')) {
             return $this->validator->setFiles($files);
         }
-
+    
         return $this->validator;
     }
 

--- a/src/Support/DelegatedValidator.php
+++ b/src/Support/DelegatedValidator.php
@@ -24,6 +24,7 @@ class DelegatedValidator
 
     /**
      * DelegatedValidator constructor.
+     *
      * @param \Illuminate\Validation\Validator $validator
      */
     public function __construct(BaseValidator $validator)
@@ -33,7 +34,11 @@ class DelegatedValidator
     }
 
     /**
+     * Call validator method
+     *
      * @param string $method
+     * @param array $args
+     * @return mixed
      */
     private function callValidator($method, $args = [])
     {
@@ -87,7 +92,11 @@ class DelegatedValidator
      */
     public function getFiles()
     {
-        return $this->validator->getFiles();
+        if (method_exists($this->validator,'getFiles')) {
+            return $this->validator->getFiles();
+        }
+
+        return [];
     }
 
     /**
@@ -99,7 +108,11 @@ class DelegatedValidator
      */
     public function setFiles(array $files)
     {
-        return $this->validator->setFiles($files);
+        if (method_exists($this->validator,'setFiles')) {
+            return $this->validator->setFiles($files);
+        }
+
+        return $this->validator;
     }
 
     /**

--- a/src/Support/DelegatedValidator.php
+++ b/src/Support/DelegatedValidator.php
@@ -111,7 +111,7 @@ class DelegatedValidator
         if (method_exists($this->validator, 'setFiles')) {
             return $this->validator->setFiles($files);
         }
-    
+
         return $this->validator;
     }
 

--- a/tests/Javascript/ValidatorHandlerTest.php
+++ b/tests/Javascript/ValidatorHandlerTest.php
@@ -41,13 +41,19 @@ class ValidatorHandlerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(false);
 
 
-        $mockRule = $this->getMock('Proengsoft\JsValidation\Javascript\RuleParser',[], [$mockDelegated] );
+        $mockRule = $this->getMockBuilder('Proengsoft\JsValidation\Javascript\RuleParser')
+            ->setConstructorArgs([$mockDelegated] )
+            ->getMock();
+
         $mockRule->expects($this->once())
             ->method('getRule')
             ->with($attribute, 'RequiredIf', ['field2','value2'])
             ->willReturn([$attribute, RuleParser::JAVASCRIPT_RULE, ['field2','value2']]);
 
-        $mockMessages = $this->getMock('Proengsoft\JsValidation\Javascript\MessageParser', [], [$mockDelegated] );
+        $mockMessages = $this->getMockBuilder('Proengsoft\JsValidation\Javascript\MessageParser')
+            ->setConstructorArgs([$mockDelegated] )
+            ->getMock();
+
         $mockMessages->expects($this->once())
             ->method('getMessage')
             ->with($attribute, 'RequiredIf', ['field2','value2'])
@@ -90,9 +96,13 @@ class ValidatorHandlerTest extends \PHPUnit_Framework_TestCase
             ->with($attribute, ValidatorHandler::JSVALIDATION_DISABLE)
             ->willReturn(true);
 
-        $mockRule = $this->getMock('Proengsoft\JsValidation\Javascript\RuleParser',[], [$mockDelegated] );
+        $mockRule = $this->getMockBuilder('Proengsoft\JsValidation\Javascript\RuleParser')
+            ->setConstructorArgs([$mockDelegated] )
+            ->getMock();
 
-        $mockMessages = $this->getMock('Proengsoft\JsValidation\Javascript\MessageParser', [], [$mockDelegated] );
+        $mockMessages = $this->getMockBuilder('Proengsoft\JsValidation\Javascript\MessageParser')
+            ->setConstructorArgs([$mockDelegated] )
+            ->getMock();
 
 
         $handler = new ValidatorHandler($mockRule, $mockMessages);
@@ -144,13 +154,19 @@ class ValidatorHandlerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(false);
 
 
-        $mockRule = $this->getMock('Proengsoft\JsValidation\Javascript\RuleParser',[], [$mockDelegated] );
+        $mockRule = $this->getMockBuilder('Proengsoft\JsValidation\Javascript\RuleParser')
+            ->setConstructorArgs([$mockDelegated] )
+            ->getMock();
+
         $mockRule->expects($this->once())
             ->method('getRule')
             ->with($attribute, 'RequiredIf', ['field2','value2'])
             ->willReturn([$attribute, RuleParser::REMOTE_RULE, ['field2','value2']]);
 
-        $mockMessages = $this->getMock('Proengsoft\JsValidation\Javascript\MessageParser', [], [$mockDelegated] );
+        $mockMessages = $this->getMockBuilder('Proengsoft\JsValidation\Javascript\MessageParser')
+            ->setConstructorArgs([$mockDelegated] )
+            ->getMock();
+
         $mockMessages->expects($this->once())
             ->method('getMessage')
             ->with($attribute, 'RequiredIf', ['field2','value2'])
@@ -200,13 +216,19 @@ class ValidatorHandlerTest extends \PHPUnit_Framework_TestCase
 
 
 
-        $mockRule = $this->getMock('Proengsoft\JsValidation\Javascript\RuleParser',[], [$mockDelegated] );
+        $mockRule = $this->getMockBuilder('Proengsoft\JsValidation\Javascript\RuleParser')
+            ->setConstructorArgs([$mockDelegated] )
+            ->getMock();
+
         $mockRule->expects($this->once())
             ->method('getRule')
             ->with($attribute, 'ActiveUrl', ['token',false,false])
             ->willReturn([$attribute, RuleParser::REMOTE_RULE, ['token',false,false]]);
 
-        $mockMessages = $this->getMock('Proengsoft\JsValidation\Javascript\MessageParser', [], [$mockDelegated] );
+        $mockMessages = $this->getMockBuilder('Proengsoft\JsValidation\Javascript\MessageParser')
+            ->setConstructorArgs([$mockDelegated] )
+            ->getMock();
+
 
 
 

--- a/tests/JsValidationServiceProviderTest.php
+++ b/tests/JsValidationServiceProviderTest.php
@@ -6,14 +6,7 @@ namespace Proengsoft\JsValidation\Tests;
 class JsValidationServiceProviderTest extends \PHPUnit_Framework_TestCase
 {
 
-
-
-    public function testBootstrapConfigs() {
-
-        $app=array();
-        $app['path.config']=dirname(__FILE__.'/../config');
-        $app['path.base']=dirname(__FILE__.'/../');
-        $app['path.public']=dirname(__FILE__.'/../public');
+    protected function getMockedService($app) {
 
         $mockedConfig = $this->getMockForAbstractClass('Illuminate\Contracts\Config\Repository',[],'',false);
         $mockedConfig->expects($this->once())
@@ -29,13 +22,24 @@ class JsValidationServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $app['validator'] = $mockedValidator;
 
+        $mock = $this->getMockBuilder('Proengsoft\JsValidation\JsValidationServiceProvider')
+            ->setMethods(['loadViewsFrom','publishes','mergeConfigFrom'])
+            ->setConstructorArgs([$app])
+            ->getMock();
+
+        return $mock;
+    }
 
 
-        $mock = $this->getMock(
-            'Proengsoft\JsValidation\JsValidationServiceProvider',
-            ['loadViewsFrom','publishes','mergeConfigFrom'],
-            [$app]
-        );
+
+    public function testBootstrapConfigs() {
+
+        $app=array();
+        $app['path.config']=dirname(__FILE__.'/../config');
+        $app['path.base']=dirname(__FILE__.'/../');
+        $app['path.public']=dirname(__FILE__.'/../public');
+
+        $mock = $this->getMockedService($app);
 
         $mock->expects($this->at(1))
             ->method('publishes')
@@ -53,27 +57,7 @@ class JsValidationServiceProviderTest extends \PHPUnit_Framework_TestCase
         $app['path.base']=dirname(__FILE__.'/../');
         $app['path.public']=dirname(__FILE__.'/../public');
 
-        $mockedConfig = $this->getMockForAbstractClass('Illuminate\Contracts\Config\Repository',[],'',false);
-        $mockedConfig->expects($this->once())
-            ->method('get')
-            ->with('jsvalidation.disable_remote_validation')
-            ->will($this->returnValue(true));
-        $app['config']=$mockedConfig;
-
-        $mockedValidator = $this->getMockForAbstractClass('Illuminate\Contracts\Validation\Factory',[],'',false);
-        $mockedValidator->expects($this->once())
-            ->method('extend')
-            ->will($this->returnValue(null));
-
-        $app['validator'] = $mockedValidator;
-
-        $mock = $this->getMock(
-            'Proengsoft\JsValidation\JsValidationServiceProvider',
-            ['loadViewsFrom','publishes','mergeConfigFrom'],
-            [$app]
-        );
-
-
+        $mock = $this->getMockedService($app);
 
         $mock->expects($this->once())
             ->method('loadViewsFrom')
@@ -97,26 +81,7 @@ class JsValidationServiceProviderTest extends \PHPUnit_Framework_TestCase
         $app['path.base']=dirname(__FILE__.'/../');
         $app['path.public']=dirname(__FILE__.'/../public');
 
-        $mockedConfig = $this->getMockForAbstractClass('Illuminate\Contracts\Config\Repository',[],'',false);
-        $mockedConfig->expects($this->once())
-            ->method('get')
-            ->with('jsvalidation.disable_remote_validation')
-            ->will($this->returnValue(true));
-        $app['config']=$mockedConfig;
-
-        $mockedValidator = $this->getMockForAbstractClass('Illuminate\Contracts\Validation\Factory',[],'',false);
-        $mockedValidator->expects($this->once())
-            ->method('extend')
-            ->will($this->returnValue(null));
-
-        $app['validator'] = $mockedValidator;
-
-        $mock = $this->getMock(
-            'Proengsoft\JsValidation\JsValidationServiceProvider',
-            ['loadViewsFrom','publishes','mergeConfigFrom'],
-            [$app]
-        );
-
+        $mock = $this->getMockedService($app);
 
         $mock->expects($this->at(4))
             ->method('publishes')
@@ -135,6 +100,7 @@ class JsValidationServiceProviderTest extends \PHPUnit_Framework_TestCase
         $app['path.config']=dirname(__FILE__.'/../config');
         $app['path.base']=dirname(__FILE__.'/../');
         $app['path.public']=dirname(__FILE__.'/../public');
+
 
         $mockedConfig = $this->getMockForAbstractClass('Illuminate\Contracts\Config\Repository',[],'',false);
         $mockedConfig->expects($this->once())
@@ -155,20 +121,18 @@ class JsValidationServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $app['Illuminate\Contracts\Http\Kernel'] = $mockKernel;
 
-
-        $mock = $this->getMock(
-            'Proengsoft\JsValidation\JsValidationServiceProvider',
-            ['loadViewsFrom','publishes','mergeConfigFrom'],
-            [$app]
-        );
-
+        $mock = $this->getMockBuilder('Proengsoft\JsValidation\JsValidationServiceProvider')
+            ->setConstructorArgs([$app])
+            ->setMethods(['loadViewsFrom','publishes','mergeConfigFrom'])
+            ->getMock();
 
         $mock->boot();
 
     }
 
     public function testRegister() {
-        $app = $this->getMock('Illuminate\Contracts\Container\Container');
+        $app = $this->getMockBuilder('Illuminate\Contracts\Container\Container')
+            ->getMock();
 
         $app->expects($this->once())
             ->method('singleton')
@@ -187,11 +151,11 @@ class JsValidationServiceProviderTest extends \PHPUnit_Framework_TestCase
             });
 
 
-        $mock = $this->getMock(
-            'Proengsoft\JsValidation\JsValidationServiceProvider',
-            ['loadViewsFrom','publishes','mergeConfigFrom'],
-            [$app]
-        );
+        $mock = $this->getMockBuilder('Proengsoft\JsValidation\JsValidationServiceProvider')
+            ->setConstructorArgs([$app])
+            ->setMethods(['loadViewsFrom','publishes','mergeConfigFrom'])
+            ->getMock();
+
         $mock->register();
 
     }

--- a/tests/JsValidatorFactoryTest.php
+++ b/tests/JsValidatorFactoryTest.php
@@ -10,37 +10,46 @@ require_once __DIR__.'/stubs/JsValidatorFactoryTest.php';
 class JsValidatorFactoryTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function testMake() {
-        $rules=['name'=>'required'];
-        $messages = [];
-        $customAttributes = [];
-        $selector = null;
+    protected function mockedApp($rules, $messages, $customAttributes) {
 
+        $mockValidator = $this->getMockBuilder('\Illuminate\Validation\Validator')
+            ->disableOriginalConstructor()
+            ->setMethods(['addCustomAttributes'])
+            ->getMock();
 
-        $mockValidator = $this->getMock(
-            '\Illuminate\Validation\Validator',['addCustomAttributes'],
-            [], '', false
-        );
         $mockValidator->expects($this->once())
             ->method('addCustomAttributes')
             ->with($customAttributes);
 
+        $mockFactory = $this->getMockBuilder('Illuminate\Contracts\Validation\Factory')
+            ->disableOriginalConstructor()
+            ->setMethods(['make','extend','extendImplicit','replacer'])
+            ->getMock();
 
-        $mockFactory = $this->getMock(
-            'Illuminate\Contracts\Validation\Factory',
-            ['make','extend','extendImplicit','replacer'], [], '', false
-        );
         $mockFactory->expects($this->once())
             ->method('make')
             ->with([], $rules, $messages, $customAttributes)
             ->willReturn($mockValidator);
 
 
-        $app = $this->getMock('\Illuminate\Container\Container');
+        $app = $this->getMockBuilder('\Illuminate\Container\Container')
+            ->getMock();
         $app->expects($this->once())
             ->method('make')
             ->with('Illuminate\Contracts\Validation\Factory')
             ->willReturn($mockFactory);
+
+        return $app;
+
+    }
+
+    public function testMake() {
+        $rules=['name'=>'required'];
+        $messages = [];
+        $customAttributes = [];
+        $selector = null;
+
+        $app = $this->mockedApp($rules, $messages, $customAttributes);
 
         $app->expects($this->at(1))
             ->method('__get')
@@ -71,43 +80,23 @@ class JsValidatorFactoryTest extends \PHPUnit_Framework_TestCase
         $customAttributes = [];
         $selector = null;
 
-
-        $mockValidator = $this->getMock(
-            '\Illuminate\Validation\Validator',['addCustomAttributes'],
-            [], '', false
-        );
-        $mockValidator->expects($this->once())
-            ->method('addCustomAttributes')
-            ->with($customAttributes);
-
-
-        $mockFactory = $this->getMock(
-            'Illuminate\Contracts\Validation\Factory',
-            ['make','extend','extendImplicit','replacer'], [], '', false
-        );
-        $mockFactory->expects($this->once())
-            ->method('make')
-            ->with([], $rules, $messages, $customAttributes)
-            ->willReturn($mockValidator);
-
-
-        $app = $this->getMock('\Illuminate\Container\Container');
-        $app->expects($this->once())
-            ->method('make')
-            ->with('Illuminate\Contracts\Validation\Factory')
-            ->willReturn($mockFactory);
-
-        $sessionMock = $this->getMock('stdObject',['token']);
+        $sessionMock = $this->getMockBuilder('stdObject')
+            ->setMethods(['token'])
+            ->getMock();
         $sessionMock->expects($this->once())
             ->method('token')
             ->willReturn('token');
+
+        $app = $this->mockedApp($rules, $messages, $customAttributes);
 
         $app->expects($this->at(1))
             ->method('__get')
             ->with('session')
             ->willReturn($sessionMock);
 
-        $encrypterMock = $this->getMock('stdObject',['encrypt']);
+        $encrypterMock = $this->getMockBuilder('stdObject')
+            ->setMethods(['encrypt'])
+            ->getMock();
         $encrypterMock->expects($this->once())
             ->method('encrypt')
             ->with('token')
@@ -131,7 +120,7 @@ class JsValidatorFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testCreateFromFormRequestInstance() {
-        $rules=['name'=>'required'];
+        $rules=[];
         $messages = [];
         $customAttributes = [];
         $selector = null;
@@ -140,31 +129,7 @@ class JsValidatorFactoryTest extends \PHPUnit_Framework_TestCase
         $options['view'] = 'jsvalidation::bootstrap';
         $options['form_selector'] = 'form';
 
-        $mockValidator = $this->getMock(
-            '\Illuminate\Validation\Validator',['addCustomAttributes'],
-            [], '', false
-        );
-        $mockValidator->expects($this->once())
-            ->method('addCustomAttributes')
-            ->with($customAttributes);
-
-
-        $mockFactory = $this->getMock(
-            'Illuminate\Contracts\Validation\Factory',
-            ['make','extend','extendImplicit','replacer'], [], '', false
-        );
-        $mockFactory->expects($this->once())
-            ->method('make')
-            ->with([], [], $messages, $customAttributes)
-            ->willReturn($mockValidator);
-
-
-        $app = $this->getMock('\Illuminate\Container\Container');
-        $app->expects($this->once())
-            ->method('make')
-            ->with('Illuminate\Contracts\Validation\Factory')
-            ->willReturn($mockFactory);
-
+        $app = $this->mockedApp($rules, $messages, $customAttributes);
 
         $mockFormRequest=m::mock('Illuminate\Foundation\Http\FormRequest');
         $mockFormRequest->shouldReceive('rules')->once()->andReturn($rules);
@@ -182,7 +147,7 @@ class JsValidatorFactoryTest extends \PHPUnit_Framework_TestCase
 
 
     public function testCreateFromFormRequestClassName() {
-        $rules=['name'=>'required'];
+        $rules=[];
         $messages = [];
         $customAttributes = [];
         $selector = null;
@@ -191,33 +156,11 @@ class JsValidatorFactoryTest extends \PHPUnit_Framework_TestCase
         $options['view'] = 'jsvalidation::bootstrap';
         $options['form_selector'] = 'form';
 
-        $mockValidator = $this->getMock(
-            '\Illuminate\Validation\Validator',['addCustomAttributes'],
-            [], '', false
-        );
-        $mockValidator->expects($this->once())
-            ->method('addCustomAttributes')
-            ->with($customAttributes);
 
+        $app = $this->mockedApp($rules, $messages, $customAttributes);
 
-        $mockFactory = $this->getMock(
-            'Illuminate\Contracts\Validation\Factory',
-            ['make','extend','extendImplicit','replacer'], [], '', false
-        );
-        $mockFactory->expects($this->once())
-            ->method('make')
-            ->with([], [], $messages, $customAttributes)
-            ->willReturn($mockValidator);
-
-
-        $app = $this->getMock('\Illuminate\Container\Container');
-
-        $app->expects($this->once())
-            ->method('make')
-            ->with('Illuminate\Contracts\Validation\Factory')
-            ->willReturn($mockFactory);
-
-        $sessionMock = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface',[]);
+        $sessionMock = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')
+            ->getMock();
 
 
         $mockedRequest = m::mock('\Symfony\Component\HttpFoundation\Request');

--- a/tests/Remote/ResolverTest.php
+++ b/tests/Remote/ResolverTest.php
@@ -21,6 +21,14 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    protected function getMockedTranslator() {
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
+            ->getMock();
+
+        return $translator;
+
+    }
+
     public function testResolverIsClosure() {
 
 
@@ -35,7 +43,8 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
         $resolver = $this->resolverObject->resolver('field');
 
 
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
+            ->getMock();
         $validator = $resolver($translator,[],[],[],[]);
 
         $this->assertInstanceOf('Illuminate\Validation\Validator', $validator);
@@ -45,12 +54,13 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolvesValidatorExists() {
 
 
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
+            ->getMock();
         $resolverObject = new Resolver(new CustomValidatorStubTest($translator));
 
         $resolver = $resolverObject->resolver('field');
-
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
+            ->getMock();
         $validator = $resolver($translator,[],[],[],[]);
 
         $this->assertInstanceOf('Illuminate\Validation\Validator', $validator);
@@ -65,12 +75,14 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testResolvesAndValidated() {
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
+            ->getMock();
         $resolverObject = new Resolver(new CustomValidatorStubTest($translator));
 
         $resolver = $resolverObject->resolver('field');
 
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
+            ->getMock();
         $validator = $resolver($translator,
             ['field'=>'value', '_jsvalidation_validate_all'=>false],
             ['field'=>'required'],

--- a/tests/Remote/ValidatorTest.php
+++ b/tests/Remote/ValidatorTest.php
@@ -75,17 +75,21 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
     protected function getRealTranslator()
     {
-        $trans = new \Symfony\Component\Translation\Translator('en', new \Symfony\Component\Translation\MessageSelector);
-        $trans->addLoader('array', new \Symfony\Component\Translation\Loader\ArrayLoader);
-        $trans->addResource(
-            'array',
-            [
-                'validation.required' => ':attribute required!',
-                'validation.active_url' => ':attribute active_url!'
-            ],
-            'en',
-            'messages'
-        );
+        $messages = [
+            'validation.required' => ':attribute required!',
+            'validation.active_url' => ':attribute active_url!'
+        ];
+
+        if (method_exists('\Illuminate\Translation\Translator','addLines')) {
+            $trans = new \Illuminate\Translation\Translator(
+                new \Illuminate\Translation\ArrayLoader, 'en'
+            );
+            $trans->addLines( $messages, 'en');
+        } else {
+            $trans = new \Symfony\Component\Translation\Translator('en', new \Symfony\Component\Translation\MessageSelector);
+            $trans->addLoader('array', new \Symfony\Component\Translation\Loader\ArrayLoader);
+            $trans->addResource('array', $messages , 'en', 'messages' );
+        }
 
         return $trans;
     }

--- a/tests/Support/DelegatedValidatorTest.php
+++ b/tests/Support/DelegatedValidatorTest.php
@@ -71,7 +71,38 @@ class DelegatedValidatorTest extends PHPUnit_Framework_TestCase
     public function testGetFiles()
     {
         $expected = ['field'=>'data'];
-        $this->callValidatorMethod('getFiles',$expected);
+
+        $validator = $this->getMockBuilder('\Illuminate\Validation\Validator')
+            ->disableOriginalConstructor()
+            ->setMethods(['getFiles'])
+            ->getMock();
+
+        $validator->expects($this->once())
+            ->method('getFiles')
+            ->willReturn($expected);
+
+        $delegated = new DelegatedValidator($validator);
+        $files = $delegated->getFiles();
+
+        $this->assertEquals($expected, $files);
+    }
+
+    /**
+     * Test Get the files in Laravel >= 5.3.21
+     */
+    public function testGetFilesMethodNotExists() {
+        $expected = [];
+        $validator = $this->getMockBuilder('\Illuminate\Validation\Validator')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $validator->method($this->anything())
+            ->willReturn($expected);
+
+        $delegated = new DelegatedValidator($validator);
+        $files = $delegated->getFiles();
+
+
+        $this->assertEquals($expected, $files);
     }
 
     /**
@@ -80,12 +111,47 @@ class DelegatedValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function testSetFiles()
     {
-        $expected = ['field'=>'data'];
-        $this->callValidatorMethodWithArg('setFiles',$expected, null);
+        $return = true;
+        $arg=[];
 
+        $validator = $this->getMockBuilder('\Illuminate\Validation\Validator')
+            ->disableOriginalConstructor()
+            ->setMethods(['setFiles'])
+            ->getMock();
+
+        $validator->expects($this->once())
+            ->method('setFiles')
+            ->with($arg)
+            ->willReturn($return );
+
+        $delegated = new DelegatedValidator($validator);
+        $result = $delegated->setFiles($arg);
+
+        $this->assertEquals($return , $result);
 
     }
 
+    /**
+     * Test Set the files in Laravel >= 5.3.21
+     *
+     */
+    public function testSetFilesMethodNotExists()
+    {
+        $arg=[];
+
+        $validator = $this->getMockBuilder('\Illuminate\Validation\Validator')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $validator->method($this->anything())
+            ->willReturn($validator);
+
+        $delegated = new DelegatedValidator($validator);
+        $result = $delegated->setFiles($arg);
+
+        $this->assertEquals($validator , $result);
+
+    }
     /**
      * Test Explode rules.
      *
@@ -183,7 +249,6 @@ class DelegatedValidatorTest extends PHPUnit_Framework_TestCase
             ->willReturn($return);
 
         $delegated = new DelegatedValidator($validator);
-        //$value= $delegated->$method();
         $value=call_user_func_array([$delegated, $method],$args);
 
         $this->assertEquals($return, $value);
@@ -229,8 +294,10 @@ class DelegatedValidatorTest extends PHPUnit_Framework_TestCase
             ->getMock();
 
 
-        $delegated = $this->getMock('\Proengsoft\JsValidation\Support\DelegatedValidator',['callProtected'],[$validator]);
-
+        $delegated = $this->getMockBuilder('\Proengsoft\JsValidation\Support\DelegatedValidator')
+            ->setConstructorArgs([$validator])
+            ->setMethods(['callProtected'])
+            ->getMock();
         $delegated->expects($this->once())
             ->method('callProtected')
             ->with($this->isInstanceOf('Closure'), $method, $this->isType('array'))


### PR DESCRIPTION
Laravel v5.3.21 (And 5.4) have breaking changes with the way `validator->getFiles()` and `validator->setFiles()` work.

This PR fixes #190 

Thanks to @reganjohnson
