### PR TITLE
Laravel 5.4 Fixes with Tests

### DIFF
--- a/src/Javascript/MessageParser.php
+++ b/src/Javascript/MessageParser.php
@@ -34,7 +34,7 @@ class MessageParser
         $data = $this->fakeValidationData($attribute, $rule, $parameters);
 
         $message = $this->validator->getMessage($attribute, $rule);
-        $message = $this->validator->doReplacements($message, $attribute, $rule, $parameters);
+        $message = $this->validator->makeReplacements($message, $attribute, $rule, $parameters);
 
         $this->validator->setData($data);
 

--- a/src/JsValidatorFactory.php
+++ b/src/JsValidatorFactory.php
@@ -157,7 +157,7 @@ class JsValidatorFactory
         $formRequest = $this->app->build($class, $params);
 
         if ($session = $request->getSession()) {
-            $formRequest->setSession($session);
+            $formRequest->setLaravelSession($session);
         }
         $formRequest->setUserResolver($request->getUserResolver());
         $formRequest->setRouteResolver($request->getRouteResolver());

--- a/src/JsValidatorFactory.php
+++ b/src/JsValidatorFactory.php
@@ -10,6 +10,7 @@ use Proengsoft\JsValidation\Javascript\MessageParser;
 use Proengsoft\JsValidation\Support\DelegatedValidator;
 use Proengsoft\JsValidation\Javascript\ValidatorHandler;
 use Proengsoft\JsValidation\Javascript\JavascriptValidator;
+use Proengsoft\JsValidation\Support\ValidationRuleParserProxy;
 
 class JsValidatorFactory
 {
@@ -194,7 +195,7 @@ class JsValidatorFactory
         $view = $this->options['view'];
         $selector = is_null($selector) ? $this->options['form_selector'] : $selector;
 
-        $delegated = new DelegatedValidator($validator);
+        $delegated = new DelegatedValidator($validator, new ValidationRuleParserProxy());
         $rules = new RuleParser($delegated, $this->getSessionToken());
         $messages = new MessageParser($delegated);
 

--- a/src/Remote/Validator.php
+++ b/src/Remote/Validator.php
@@ -3,6 +3,7 @@
 namespace Proengsoft\JsValidation\Remote;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\ValidationRuleParser;
 use Proengsoft\JsValidation\Support\RuleListTrait;
 use Illuminate\Http\Exception\HttpResponseException;
 use Illuminate\Validation\Validator as BaseValidator;
@@ -153,7 +154,7 @@ class Validator
         $protectedValidator = $this->createProtectedCaller($validator);
 
         foreach ($rules as $i => $rule) {
-            $parsedRule = call_user_func($protectedValidator, 'parseRule', [$rule]);
+            $parsedRule = ValidationRuleParser::parse([$rule]);
             if (! $this->isRemoteRule($parsedRule[0])) {
                 unset($rules[$i]);
             }

--- a/src/Remote/Validator.php
+++ b/src/Remote/Validator.php
@@ -5,7 +5,7 @@ namespace Proengsoft\JsValidation\Remote;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Validation\ValidationRuleParser;
 use Proengsoft\JsValidation\Support\RuleListTrait;
-use Illuminate\Http\Exception\HttpResponseException;
+use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Validation\Validator as BaseValidator;
 use Proengsoft\JsValidation\Support\AccessProtectedTrait;
 
@@ -58,7 +58,7 @@ class Validator
      * @param  \Illuminate\Validation\Validator  $validator
      * @return void
      *
-     * @throws \Illuminate\Validation\ValidationException|\Illuminate\Http\Exception\HttpResponseException
+     * @throws \Illuminate\Validation\ValidationException|\Illuminate\Http\Exceptions\HttpResponseException
      */
     protected function throwValidationException($result, $validator)
     {

--- a/src/Support/DelegatedValidator.php
+++ b/src/Support/DelegatedValidator.php
@@ -4,7 +4,6 @@ namespace Proengsoft\JsValidation\Support;
 
 use Closure;
 use Illuminate\Validation\Validator as BaseValidator;
-use Illuminate\Validation\ValidationRuleParser;
 
 class DelegatedValidator
 {
@@ -17,6 +16,13 @@ class DelegatedValidator
     protected $validator;
 
     /**
+     * Validation rule parser instance.
+     *
+     * @var \Proengsoft\JsValidation\Support\ValidationRuleParserProxy
+     */
+    protected $ruleParser;
+
+    /**
      *  Closure to invoke non accessible Validator methods.
      *
      * @var Closure
@@ -27,10 +33,12 @@ class DelegatedValidator
      * DelegatedValidator constructor.
      *
      * @param \Illuminate\Validation\Validator $validator
+     * @param \Proengsoft\JsValidation\Support\ValidationRuleParserProxy $ruleParser
      */
-    public function __construct(BaseValidator $validator)
+    public function __construct(BaseValidator $validator, ValidationRuleParserProxy $ruleParser)
     {
         $this->validator = $validator;
+        $this->ruleParser = $ruleParser;
         $this->validatorMethod = $this->createProtectedCaller($validator);
     }
 
@@ -108,7 +116,7 @@ class DelegatedValidator
      *
      * @return string
      */
-    public function doReplacements($message, $attribute, $rule, $parameters)
+    public function makeReplacements($message, $attribute, $rule, $parameters)
     {
         return $this->callValidator('makeReplacements', [$message, $attribute, $rule, $parameters]);
     }
@@ -148,7 +156,7 @@ class DelegatedValidator
      */
     public function parseRule($rules)
     {
-        return ValidationRuleParser::parse($rules);
+        return $this->ruleParser->parse($rules);
     }
 
     /**

--- a/src/Support/DelegatedValidator.php
+++ b/src/Support/DelegatedValidator.php
@@ -4,6 +4,7 @@ namespace Proengsoft\JsValidation\Support;
 
 use Closure;
 use Illuminate\Validation\Validator as BaseValidator;
+use Illuminate\Validation\ValidationRuleParser;
 
 class DelegatedValidator
 {
@@ -147,7 +148,7 @@ class DelegatedValidator
      */
     public function parseRule($rules)
     {
-        return $this->callValidator('parseRule', [$rules]);
+        return ValidationRuleParser::parse($rules);
     }
 
     /**

--- a/src/Support/DelegatedValidator.php
+++ b/src/Support/DelegatedValidator.php
@@ -110,7 +110,7 @@ class DelegatedValidator
      */
     public function doReplacements($message, $attribute, $rule, $parameters)
     {
-        return $this->callValidator('doReplacements', [$message, $attribute, $rule, $parameters]);
+        return $this->callValidator('makeReplacements', [$message, $attribute, $rule, $parameters]);
     }
 
     /**

--- a/src/Support/ValidationRuleParserProxy.php
+++ b/src/Support/ValidationRuleParserProxy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Proengsoft\JsValidation\Support;
+
+use Illuminate\Validation\ValidationRuleParser;
+
+class ValidationRuleParserProxy
+{
+    /**
+     * Extract the rule name and parameters from a rule.
+     *
+     * @param  array|string  $rules
+     * @return array
+     */
+    public function parse($rules)
+    {
+        return ValidationRuleParser::parse($rules);
+    }
+}

--- a/tests/Javascript/MessageParserTest.php
+++ b/tests/Javascript/MessageParserTest.php
@@ -7,11 +7,8 @@ use Proengsoft\JsValidation\Javascript\MessageParser;
 
 class MessageParserTest extends \PHPUnit_Framework_TestCase
 {
-
-
-
-    public function testGetMessage() {
-
+    public function testGetMessage()
+    {
         $attribute = 'field';
         $rule = 'Required';
         $params=[];
@@ -36,7 +33,7 @@ class MessageParserTest extends \PHPUnit_Framework_TestCase
             ->willReturn("$attribute $rule");
 
         $delegated->expects($this->once())
-            ->method('doReplacements')
+            ->method('makeReplacements')
             ->with("$attribute $rule",$attribute,$rule, $params)
             ->willReturn("$attribute $rule");
 
@@ -78,7 +75,7 @@ class MessageParserTest extends \PHPUnit_Framework_TestCase
             ->willReturn("$attribute $rule");
 
         $delegated->expects($this->once())
-            ->method('doReplacements')
+            ->method('makeReplacements')
             ->with("$attribute $rule",$attribute,$rule, $params)
             ->willReturn("$attribute $rule");
 
@@ -119,7 +116,7 @@ class MessageParserTest extends \PHPUnit_Framework_TestCase
             ->willReturn("$attribute $rule");
 
         $delegated->expects($this->once())
-            ->method('doReplacements')
+            ->method('makeReplacements')
             ->with("$attribute $rule",$attribute,$rule, $params)
             ->willReturn("$attribute $rule");
 

--- a/tests/Remote/ResolverTest.php
+++ b/tests/Remote/ResolverTest.php
@@ -3,7 +3,7 @@
 
 namespace Proengsoft\JsValidation\Tests\Remote;
 
-use Illuminate\Http\Exception\HttpResponseException;
+use Illuminate\Http\Exceptions\HttpResponseException;
 use Proengsoft\JsValidation\Remote\Resolver;
 
 require_once __DIR__.'/../stubs/ResolverTest.php';

--- a/tests/Remote/ResolverTest.php
+++ b/tests/Remote/ResolverTest.php
@@ -22,7 +22,7 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     protected function getMockedTranslator() {
-        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
+        $translator = $this->getMockBuilder('Illuminate\Contracts\Translation\Translator')
             ->getMock();
 
         return $translator;
@@ -43,8 +43,7 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
         $resolver = $this->resolverObject->resolver('field');
 
 
-        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
-            ->getMock();
+        $translator = $this->getMockedTranslator();
         $validator = $resolver($translator,[],[],[],[]);
 
         $this->assertInstanceOf('Illuminate\Validation\Validator', $validator);
@@ -54,13 +53,11 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolvesValidatorExists() {
 
 
-        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
-            ->getMock();
+        $translator = $this->getMockedTranslator();
         $resolverObject = new Resolver(new CustomValidatorStubTest($translator));
 
         $resolver = $resolverObject->resolver('field');
-        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
-            ->getMock();
+        $translator = $this->getMockedTranslator();
         $validator = $resolver($translator,[],[],[],[]);
 
         $this->assertInstanceOf('Illuminate\Validation\Validator', $validator);
@@ -75,14 +72,12 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testResolvesAndValidated() {
-        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
-            ->getMock();
+        $translator = $this->getMockedTranslator();
         $resolverObject = new Resolver(new CustomValidatorStubTest($translator));
 
         $resolver = $resolverObject->resolver('field');
 
-        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
-            ->getMock();
+        $translator = $this->getMockedTranslator();
         $validator = $resolver($translator,
             ['field'=>'value', '_jsvalidation_validate_all'=>false],
             ['field'=>'required'],

--- a/tests/Remote/ValidatorTest.php
+++ b/tests/Remote/ValidatorTest.php
@@ -2,7 +2,7 @@
 
 namespace Proengsoft\JsValidation\Tests\Remote;
 
-use Illuminate\Http\Exception\HttpResponseException;
+use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Validation\Validator as LaravelValidator;
 use Proengsoft\JsValidation\Exceptions\BadRequestHttpException;
 use Proengsoft\JsValidation\Javascript\ValidatorHandler;

--- a/tests/stubs/JsValidatorFactoryTest.php
+++ b/tests/stubs/JsValidatorFactoryTest.php
@@ -3,7 +3,7 @@ namespace  Illuminate\Foundation\Http {
     if (!class_exists('FormRequest')) {
         class  FormRequest {
             public function initialize(){}
-            public function setSession(){}
+            public function setLaravelSession(){}
             public function setUserResolver(){}
             public function setRouteResolver() {}
             public function setContainer() {}


### PR DESCRIPTION
I've updated the code and the tests to work with Laravel 5.4 and thus created breaking changes against previous versions. I wasn't sure what to do with your testing setup as there are multiple `composer.json`'s for the different Laravel versions to be tested. But these don't seem to be needed anymore as the code changes I've done will break on previous Laravel versions.

I've had to create a proxy class for the `ValidationRuleParser` because its parse function is static and it didn't seem like you could mock static functions. I've done this to allow the `DelegatedValidator` to be tested. Annoyingly it will be the only class in your code base not being tested, so interested in what your thoughts are.

Thanks
Chris