### PR TITLE
Fix array wildcard validation in Laravel 5.4 (#297)

### DIFF
--- a/src/JsValidatorFactory.php
+++ b/src/JsValidatorFactory.php
@@ -64,7 +64,7 @@ class JsValidatorFactory
     {
         $validator = $this->getValidatorInstance($rules, $messages, $customAttributes);
 
-        return $this->validator($validator, $selector);
+        return str_replace('[#]', '[*]', $this->validator($validator, $selector)->render());
     }
 
     /**
@@ -99,6 +99,9 @@ class JsValidatorFactory
         });
 
         $attributes = array_merge(array_keys($customAttributes), $attributes);
+        
+        $attributes = str_replace('*', '#', $attributes);
+        
         $data = array_reduce($attributes, function ($data, $attribute) {
             Arr::set($data, $attribute, true);
 


### PR DESCRIPTION
I know it is a very dirty fix, but my OOP knowledge doesn't allow me to do it in a better way. At least, I have found a problem. 
The problem is `addRules()` method in new Laravel `Validator`  class. It uses `ValidationRuleParser` to transform all the rules with `*` into `implicitAttributes` and `explicitRules` properties, that will be set based on real data ( * => 0, 1, 2 etc), but we don't have any real data when we try to grab set of rules from `FormRequest` class. And these `implicitAttributes` are not added to 'rules' array that is used in JsValidatior to build rules. 
So, the main idea to change `*` with something else to trick `ValidationRuleParser` and then change it back.
