### PR TITLE
[Laravel 5.6] Symfony no longer accepts a string as an error

### DIFF
--- a/src/Javascript/MessageParser.php
+++ b/src/Javascript/MessageParser.php
@@ -103,6 +103,6 @@ class MessageParser
      */
     protected function createUploadedFile()
     {
-        return new UploadedFile('fakefile', 'fakefile', null, null, 'fakefile', true);
+        return new UploadedFile('fakefile', 'fakefile', null, null, UPLOAD_ERR_NO_FILE, true);
     }
 }


### PR DESCRIPTION
In symfony 4.0+ Symfony\Component\HttpFoundation\File\UploadedFile strictly expects the fifth argument to be an integer. Passing an actual valid PHP error constant like UPLOAD_ERR_NO_FILE instead of a string fixes this error when working with file related validation rules like images, mimetypes, files. 

Without this fix the following error is thrown whenever a validation rule is used
```
Proengsoft\JsValidation\Javascript\JavascriptValidator::__toString() must not throw an exception, caught TypeError: Argument 5 passed to Symfony\Component\HttpFoundation\File\UploadedFile::__construct() must be of the type integer or null, string given, called in /home/vagrant/sites/gmodstore/vendor/proengsoft/laravel-jsvalidation/src/Javascript/MessageParser.php on line 106
```

This is a fix for #304