### PR TITLE
Fix for custom rules

### DIFF
--- a/src/Support/DelegatedValidator.php
+++ b/src/Support/DelegatedValidator.php
@@ -116,6 +116,10 @@ class DelegatedValidator
      */
     public function makeReplacements($message, $attribute, $rule, $parameters)
     {
+        if (is_object($rule)) {
+            $rule = get_class($rule);
+        }
+        
         return $this->callValidator('makeReplacements', [$message, $attribute, $rule, $parameters]);
     }
 
@@ -140,6 +144,10 @@ class DelegatedValidator
      */
     public function getMessage($attribute, $rule)
     {
+        if (is_object($rule)) {
+            $rule = get_class($rule);
+        }
+        
         return $this->callValidator('getMessage', [$attribute, $rule]);
     }
 

--- a/tests/Support/DelegatedValidatorTest.php
+++ b/tests/Support/DelegatedValidatorTest.php
@@ -194,6 +194,14 @@ class DelegatedValidatorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     *  Test Replace all error message place-holders with actual object value.
+     */
+    public function testMakeReplacementsObject()
+    {
+        $this->callValidatorProtectedMethod('makeReplacements', (object) ['message','attribute','rule',[]]);
+    }
+
+    /**
      * Test if the given attribute has a rule in the given set.
      *
      */
@@ -208,6 +216,14 @@ class DelegatedValidatorTest extends PHPUnit_Framework_TestCase
     public function testGetMessage()
     {
         $this->callValidatorProtectedMethod('getMessage', ['attribute','rule']);
+    }
+
+    /**
+     * Test the validation message for object with  attribute and rule.
+     */
+    public function testGetMessageObject()
+    {
+        $this->callValidatorProtectedMethod('getMessage', (object) ['attribute','rule']);
     }
 
     /**

--- a/tests/Support/DelegatedValidatorTest.php
+++ b/tests/Support/DelegatedValidatorTest.php
@@ -198,7 +198,6 @@ class DelegatedValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function testMakeReplacementsObject()
     {
-        $this->callValidatorProtectedMethod('makeReplacements', (object) ['message','attribute','rule',[]]);
     }
 
     /**
@@ -223,7 +222,7 @@ class DelegatedValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function testGetMessageObject()
     {
-        $this->callValidatorProtectedMethod('getMessage', (object) ['attribute','rule']);
+        $this->callValidatorProtectedMethod('getMessage', ['attribute', (object) []]);
     }
 
     /**

--- a/tests/Support/DelegatedValidatorTest.php
+++ b/tests/Support/DelegatedValidatorTest.php
@@ -198,6 +198,7 @@ class DelegatedValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function testMakeReplacementsObject()
     {
+        $this->callValidatorProtectedMethod('makeReplacements', ['message','attribute','rule',(object) []]);
     }
 
     /**


### PR DESCRIPTION
Added check and conversion of Rule that's an object ref #313 

In addition to this fix, for custom rules, another error will be thrown by the Illuminate `ValidationRulesParser.php` about the object error. The solution to this is to define the `__toString` in your rule like so.. replacing the returned string with your rule name.

```php
public function __toString()
{
    return 'USPhoneNumber';
}
```