### PR TITLE
Fixed #245

### DIFF
--- a/src/JsValidatorFactory.php
+++ b/src/JsValidatorFactory.php
@@ -202,7 +202,7 @@ class JsValidatorFactory
         $view = $this->options['view'];
         $selector = is_null($selector) ? $this->options['form_selector'] : $selector;
 
-        $delegated = new DelegatedValidator($validator, new ValidationRuleParserProxy());
+        $delegated = new DelegatedValidator($validator, new ValidationRuleParserProxy($validator->getData()));
         $rules = new RuleParser($delegated, $this->getSessionToken());
         $messages = new MessageParser($delegated);
 

--- a/src/Support/DelegatedValidator.php
+++ b/src/Support/DelegatedValidator.php
@@ -170,7 +170,7 @@ class DelegatedValidator
      */
     public function explodeRules($rules)
     {
-        return $this->callValidator('explodeRules', [$rules]);
+        return $this->ruleParser->explodeRules($rules);
     }
 
     /**

--- a/tests/Support/DelegatedValidatorTest.php
+++ b/tests/Support/DelegatedValidatorTest.php
@@ -173,8 +173,8 @@ class DelegatedValidatorTest extends TestCase
      */
     public function testExplodeRules()
     {
-        $arg='required|url';
-        $this->callValidatorProtectedMethod('explodeRules',$arg);
+        $arg = 'required|url';
+        $this->callParserMethod('explodeRules', [['required','url']], $arg);
     }
 
     /**
@@ -309,6 +309,38 @@ class DelegatedValidatorTest extends TestCase
 
         $delegated = new DelegatedValidator($validator, $parser);
         $value=call_user_func_array([$delegated, $method],$args);
+
+        $this->assertEquals($return, $value);
+    }
+
+    /**
+     * Helper to test calls to parser object.
+     *
+     * @param string $method
+     * @param mixed  $return
+     * @param array $args
+     * @return void
+     */
+    private function callParserMethod($method, $return = null, $args = [])
+    {
+        $validator = $this->getMockBuilder(\Illuminate\Validation\Validator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $parser = $this->getMockBuilder(\Proengsoft\JsValidation\Support\ValidationRuleParserProxy::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $parser->expects($this->once())
+            ->method($method)
+            ->willReturn($return);
+
+        $delegated = new DelegatedValidator($validator, $parser);
+        if (is_array($args)) {
+            $value = call_user_func_array([$delegated,$method],$args);
+        } else {
+            $value = $delegated->$method($args);
+        }
 
         $this->assertEquals($return, $value);
     }


### PR DESCRIPTION
`explodeRules` was moved out of `Validator` in https://github.com/laravel/framework/pull/17005/files

This PR resolves that issue.