### PR TITLE
Added withValidator

### DIFF
--- a/src/JsValidatorFactory.php
+++ b/src/JsValidatorFactory.php
@@ -129,6 +129,10 @@ class JsValidatorFactory
 
         $validator = $this->getValidatorInstance($rules, $formRequest->messages(), $formRequest->attributes());
 
+        if (method_exists($formRequest, 'withValidator')) {
+            $formRequest->withValidator($validator);
+        }
+        
         return $this->validator($validator, $selector);
     }
 


### PR DESCRIPTION
In Laravel 5.4 they added `withValidator()` which lets you manipulate the validator instance of a form request. This PR ensures that method gets called by js validation, and makes it easier to do [this](https://github.com/proengsoft/laravel-jsvalidation/issues/141#issuecomment-271111555) for example

> Adding After Hooks To Form Requests
> 
> If you would like to add an "after" hook to a form request, you may use the withValidator method. This method receives the fully constructed validator, allowing you to call any of its methods before the validation rules are actually evaluated:

````php
/**
 * Configure the validator instance.
 *
 * @param  \Illuminate\Validation\Validator  $validator
 * @return void
 */
public function withValidator($validator)
{
    $validator->after(function ($validator) {
        if ($this->somethingElseIsInvalid()) {
            $validator->errors()->add('field', 'Something is wrong with this field!');
        }
    });
}
````

https://laravel.com/docs/5.4/validation