### PR TITLE
Fix wrong class for bootstrap4

### DIFF
--- a/resources/views/bootstrap4.php
+++ b/resources/views/bootstrap4.php
@@ -16,7 +16,7 @@
                     }
                 },
                 highlight: function (element) {
-                    $(element).closest('.form.control').removeClass('is-valid').addClass('is-invalid'); // add the Bootstrap error class to the control group
+                    $(element).closest('.form-control').removeClass('is-valid').addClass('is-invalid'); // add the Bootstrap error class to the control group
                 },
 
                 <?php if (isset($validator['ignore']) && is_string($validator['ignore'])): ?>
@@ -31,7 +31,7 @@
                  },
                  */
                 success: function (element) {
-                    $(element).closest('.form.control').removeClass('is-invalid').addClass('is-valid'); // remove the Boostrap error class from the control group
+                    $(element).closest('.form-control').removeClass('is-invalid').addClass('is-valid'); // remove the Boostrap error class from the control group
                 },
 
                 focusInvalid: false, // do not focus the last invalid input

--- a/resources/views/bootstrap4.php
+++ b/resources/views/bootstrap4.php
@@ -24,12 +24,11 @@
                 ignore: "<?= $validator['ignore']; ?>",
                 <?php endif; ?>
 
-                /*
-                 // Uncomment this to mark as validated non required fields
-                 unhighlight: function(element) {
-                 $(element).closest('.form.control').removeClass('is-invalid').addClass('is-valid');
-                 },
-                 */
+                
+                unhighlight: function(element) {
+                    $(element).closest('.form-control').removeClass('is-invalid').addClass('is-valid');
+                },
+                
                 success: function (element) {
                     $(element).closest('.form-control').removeClass('is-invalid').addClass('is-valid'); // remove the Boostrap error class from the control group
                 },


### PR DESCRIPTION
- Fix wrong class form-control for bootstrap 4
- Remove error class when the input value becomes correct.