### PR TITLE
Allow remote validation of class-based rules without __toString() hack

### DIFF
--- a/src/Remote/Validator.php
+++ b/src/Remote/Validator.php
@@ -2,6 +2,7 @@
 
 namespace Proengsoft\JsValidation\Remote;
 
+use Illuminate\Contracts\Validation\Rule as RuleContract;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Validation\ValidationException;
@@ -158,7 +159,11 @@ class Validator
         $protectedValidator = $this->createProtectedCaller($validator);
 
         foreach ($rules as $i => $rule) {
-            $parsedRule = ValidationRuleParser::parse([$rule]);
+            $parsedRule = ValidationRuleParser::parse(
+                $rule instanceof RuleContract ?
+                    $rule :
+                    [$rule]
+            );
             if (! $this->isRemoteRule($parsedRule[0])) {
                 unset($rules[$i]);
             }

--- a/tests/stubs/ValidatorTest.php
+++ b/tests/stubs/ValidatorTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Proengsoft\JsValidation\Tests\Remote;
+
+if (interface_exists(\Illuminate\Contracts\Validation\Rule::class)) {
+    class UrlIsLaravel implements \Illuminate\Contracts\Validation\Rule
+    {
+        public function passes($attribute, $value)
+        {
+            return $value === 'https://www.laravel.com';
+        }
+
+        public function message()
+        {
+            return 'The :attribute is not https://www.laravel.com';
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/proengsoft/laravel-jsvalidation/issues/364

This allows remote validation of [rule objects](https://laravel.com/docs/5.7/validation#custom-validation-rules) supported by Laravel 5.5+ without requiring the (undocumented?) `__toString()` alias hack as suggested by pull request https://github.com/proengsoft/laravel-jsvalidation/pull/319.

The TravisCI environment only runs the test suite in Laravel 5.4 so there isn't any feedback with the new tests that are skipped when < 5.5 is installed. Along with confirming this works as intended on a local codebase, I've confirmed these tests pass with package versions:

* `illuminate/*` 5.7.23
* `phpunit/phpunit` 7.5.3
  * with tests/Remote/ValidatorTest.php changed to extend namespaced class `PHPUnit\Framework\TestCase`

For Laravel 5.4, the `instanceof` check on non-existent interface `Illuminate\Contracts\Validation\Rule` is silently skipped over.