### PR TITLE
Support all rule formats

### DIFF
--- a/src/Remote/Validator.php
+++ b/src/Remote/Validator.php
@@ -158,7 +158,7 @@ class Validator
         $protectedValidator = $this->createProtectedCaller($validator);
 
         foreach ($rules as $i => $rule) {
-            $parsedRule = ValidationRuleParser::parse([$rule]);
+            $parsedRule = ValidationRuleParser::parse($rule);
             if (! $this->isRemoteRule($parsedRule[0])) {
                 unset($rules[$i]);
             }

--- a/tests/Remote/ValidatorTest.php
+++ b/tests/Remote/ValidatorTest.php
@@ -113,7 +113,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
             ->method('throwValidationException')
             ->with($passes ? true : $this->isType('array'), $laravelValidator);
 
-        $validator->validate('field', ['validate_all' => ['true']]);
+        $validator->validate('field', []);
     }
 
     public function ruleProvider()


### PR DESCRIPTION
All rule syntaxes (string, array, RuleContract) that are supported by `Illuminate\Validation\Validator` should be supported by `Proengsoft\JsValidation\Remote\Validator`.