### PR TITLE
Added withJsValidator

### DIFF
--- a/src/Javascript/JavascriptValidator.php
+++ b/src/Javascript/JavascriptValidator.php
@@ -209,11 +209,12 @@ class JavascriptValidator implements Arrayable
     /**
      * Validate Conditional Validations using Ajax in specified fields.
      *
-     * @param string $attribute
+     * @param string       $attribute
      * @param string|array $rules
+     * @param null         $callback Dummy attribute to make API seamless with Laravel sometimes()
      * @return \Proengsoft\JsValidation\Javascript\JavascriptValidator
      */
-    public function sometimes($attribute, $rules)
+    public function sometimes($attribute, $rules, $callback = null)
     {
         $this->validator->sometimes($attribute, $rules);
 

--- a/src/JsValidatorFactory.php
+++ b/src/JsValidatorFactory.php
@@ -129,7 +129,13 @@ class JsValidatorFactory
 
         $validator = $this->getValidatorInstance($rules, $formRequest->messages(), $formRequest->attributes());
 
-        return $this->validator($validator, $selector);
+        $jsValidator = $this->validator($validator, $selector);
+        
+        if (method_exists($formRequest, 'withJsValidator')) {
+            $formRequest->withJsValidator($jsValidator);
+        }
+        
+        return $jsValidator;
     }
 
     /**

--- a/src/Support/DelegatedValidator.php
+++ b/src/Support/DelegatedValidator.php
@@ -81,7 +81,9 @@ class DelegatedValidator
      */
     public function setData($data)
     {
+        $rules = $this->validator->getRules();
         $this->validator->setData($data);
+        $this->validator->setRules($rules);
     }
 
     /**

--- a/src/Support/DelegatedValidator.php
+++ b/src/Support/DelegatedValidator.php
@@ -83,7 +83,9 @@ class DelegatedValidator
     {
         $rules = $this->validator->getRules();
         $this->validator->setData($data);
-        $this->validator->setRules($rules);
+        if (! empty($rules)) {
+            $this->validator->setRules($rules);
+        }
     }
 
     /**

--- a/src/Support/DelegatedValidator.php
+++ b/src/Support/DelegatedValidator.php
@@ -83,7 +83,7 @@ class DelegatedValidator
     {
         $rules = $this->validator->getRules();
         $this->validator->setData($data);
-        if (! empty($rules)) {
+        if (is_array($rules)) {
             $this->validator->setRules($rules);
         }
     }


### PR DESCRIPTION
Mimics Laravel's `withValidator` function, see https://laravel.com/docs/5.8/validation

> **Adding After Hooks To Form Requests**

> If you would like to add an "after" hook to a form request, you may use the withValidator method. This method receives the fully constructed validator, allowing you to call any of its methods before the validation rules are actually evaluated:

```php
/**
 * Configure the validator instance.
 *
 * @param  \Illuminate\Validation\Validator  $validator
 * @return void
 */
public function withValidator($validator)
{
    $validator->after(function ($validator) {
        if ($this->somethingElseIsInvalid()) {
            $validator->errors()->add('field', 'Something is wrong with this field!');
        }
    });
}
```