### PR TITLE
extend type to string JsValidatorFactory@formRequest

### DIFF
--- a/src/JsValidatorFactory.php
+++ b/src/JsValidatorFactory.php
@@ -114,7 +114,7 @@ class JsValidatorFactory
      * Creates JsValidator instance based on FormRequest.
      *
      * @param $formRequest
-     * @param null $selector
+     * @param null|string $selector
      * @return \Proengsoft\JsValidation\Javascript\JavascriptValidator
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException


### PR DESCRIPTION
Hello,

I'm currently upgrade a project to php7.4, and I use https://github.com/nunomaduro/larastan to help me to find some bugs.

And it find that the type of the parameter `$selector` in `JsValidatorFactory@formRequest` is defined as null type.

So I extend it to string