### PR TITLE
Fixes #297

### DIFF
--- a/src/Javascript/MessageParser.php
+++ b/src/Javascript/MessageParser.php
@@ -2,6 +2,7 @@
 
 namespace Proengsoft\JsValidation\Javascript;
 
+use Proengsoft\JsValidation\JsValidatorFactory;
 use Proengsoft\JsValidation\Support\DelegatedValidator;
 use Proengsoft\JsValidation\Support\UseDelegatedValidatorTrait;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -39,6 +40,8 @@ class MessageParser
      */
     public function getMessage($attribute, $rule, $parameters)
     {
+        $attribute = str_replace(JsValidatorFactory::ASTERISK, '*', $attribute);
+
         $data = $this->fakeValidationData($attribute, $rule, $parameters);
 
         $message = $this->validator->getMessage($attribute, $rule);

--- a/src/Javascript/RuleParser.php
+++ b/src/Javascript/RuleParser.php
@@ -2,6 +2,7 @@
 
 namespace Proengsoft\JsValidation\Javascript;
 
+use Proengsoft\JsValidation\JsValidatorFactory;
 use Proengsoft\JsValidation\Support\RuleListTrait;
 use Proengsoft\JsValidation\Support\DelegatedValidator;
 use Proengsoft\JsValidation\Support\UseDelegatedValidatorTrait;
@@ -109,8 +110,8 @@ class RuleParser
      */
     protected function isConditionalRule($attribute, $rule)
     {
-        return isset($this->conditional[$attribute]) &&
-        in_array($rule, $this->conditional[$attribute]);
+        return isset($this->conditional[$attribute])
+            && in_array($rule, $this->conditional[$attribute]);
     }
 
     /**
@@ -160,6 +161,8 @@ class RuleParser
      */
     protected function getAttributeName($attribute)
     {
+        $attribute = str_replace(JsValidatorFactory::ASTERISK, '*', $attribute);
+
         $attributeArray = explode('.', $attribute);
         if (count($attributeArray) > 1) {
             return $attributeArray[0].'['.implode('][', array_slice($attributeArray, 1)).']';

--- a/src/JsValidatorFactory.php
+++ b/src/JsValidatorFactory.php
@@ -14,6 +14,8 @@ use Proengsoft\JsValidation\Support\ValidationRuleParserProxy;
 
 class JsValidatorFactory
 {
+    const ASTERISK = '__asterisk__';
+
     /**
      * The application instance.
      *
@@ -91,7 +93,8 @@ class JsValidatorFactory
     /**
      * Gets fake data when validator has wildcard rules.
      *
-     * @param array $rules
+     * @param  array  $rules
+     * @param  array  $customAttributes
      * @return array
      */
     protected function getValidationData(array $rules, array $customAttributes = [])
@@ -102,6 +105,9 @@ class JsValidatorFactory
 
         $attributes = array_merge(array_keys($customAttributes), $attributes);
         $data = array_reduce($attributes, function ($data, $attribute) {
+            // Prevent wildcard rule being removed as an implicit attribute (not present in the data).
+            $attribute = str_replace('*', self::ASTERISK, $attribute);
+
             Arr::set($data, $attribute, true);
 
             return $data;

--- a/tests/Javascript/MessageParserTest.php
+++ b/tests/Javascript/MessageParserTest.php
@@ -162,4 +162,39 @@ class MessageParserTest extends TestCase
 
         $this->assertEquals("&lt;html&gt;", $message);
     }
+
+    /**
+     * Test array wildcard rule message.
+     *
+     * @return void
+     */
+    public function testArrayWildcardDefault()
+    {
+        $rules = ['foo.*.bar' => 'required'];
+
+        $jsValidator = $this->app['jsvalidator']->make($rules);
+
+        $rules = $jsValidator->toArray()['rules'];
+        $this->assertArrayHasKey('foo[*][bar]', $rules);
+
+        $this->assertEquals("The foo.*.bar field is required.", $rules['foo[*][bar]']['laravelValidation'][0][2]);
+    }
+
+    /**
+     * Test array wildcard rule message.
+     *
+     * @return void
+     */
+    public function testArrayWildcardCustom()
+    {
+        $rules = ['foo.*.bar' => 'required'];
+        $messages = ['foo.*.bar.required' => 'Test 123'];
+
+        $jsValidator = $this->app['jsvalidator']->make($rules, $messages);
+
+        $rules = $jsValidator->toArray()['rules'];
+        $this->assertArrayHasKey('foo[*][bar]', $rules);
+
+        $this->assertEquals("Test 123", $rules['foo[*][bar]']['laravelValidation'][0][2]);
+    }
 }

--- a/tests/Javascript/RuleParserTest.php
+++ b/tests/Javascript/RuleParserTest.php
@@ -171,4 +171,18 @@ class RuleParserTest extends TestCase
 
         $this->assertEquals($expected, $values);
     }
+
+    /**
+     * Test array wildcard rules.
+     *
+     * @return void
+     */
+    public function testArrayWildcardMaintainsAsterisk()
+    {
+        $rules = ['foo.*.bar' => 'required'];
+
+        $jsValidator = $this->app['jsvalidator']->make($rules);
+
+        $this->assertArrayHasKey('foo[*][bar]', $jsValidator->toArray()['rules']);
+    }
 }

--- a/tests/JsValidatorFactoryTest.php
+++ b/tests/JsValidatorFactoryTest.php
@@ -75,33 +75,20 @@ class JsValidatorFactoryTest extends TestCase
     public function testMakeArrayRules()
     {
         $rules=['name.*'=>'required'];
-        $data['name']['*']=true;
-        $messages = [];
-        $customAttributes = [];
-        $selector = null;
 
-        $app = $this->mockedApp($rules, $messages, $customAttributes, $data);
-
-        $app->expects($this->at(1))
-            ->method('__get')
-            ->with('session')
-            ->willReturn(null);
-
-        $app->expects($this->at(2))
-            ->method('__get')
-            ->with('encrypter')
-            ->willReturn(null);
-
-        $options = $this->app['config']->get('jsvalidation');
-        $options['disable_remote_validation'] = false;
-        $options['view'] = 'jsvalidation::bootstrap';
-        $options['form_selector'] = 'form';
-
-        $factory = new JsValidatorFactory($app, $options);
-
-        $jsValidator = $factory->make($rules, $messages, $customAttributes, $selector);
-
-        $this->assertInstanceOf(\Proengsoft\JsValidation\Javascript\JavascriptValidator::class, $jsValidator);
+        $jsValidator = $this->app['jsvalidator']->make($rules);
+        $this->assertEquals([
+            "name[*]" => [
+                "laravelValidation" => [
+                    [
+                        "Required",
+                        [],
+                        "The name.* field is required.",
+                        true
+                    ]
+                ]
+            ]
+        ], $jsValidator->toArray()['rules']);
     }
 
     public function testMakeArrayRulesAndAttributes()
@@ -113,28 +100,29 @@ class JsValidatorFactoryTest extends TestCase
         $customAttributes = ['name.*'=>'Name', 'name.key0'=>'Name Key 0'];
         $selector = null;
 
-        $app = $this->mockedApp($rules, $messages, $customAttributes, $data);
-
-        $app->expects($this->at(1))
-            ->method('__get')
-            ->with('session')
-            ->willReturn(null);
-
-        $app->expects($this->at(2))
-            ->method('__get')
-            ->with('encrypter')
-            ->willReturn(null);
-
-        $options = $this->app['config']->get('jsvalidation');
-        $options['disable_remote_validation'] = false;
-        $options['view'] = 'jsvalidation::bootstrap';
-        $options['form_selector'] = 'form';
-
-        $factory = new JsValidatorFactory($app, $options);
-
-        $jsValidator = $factory->make($rules, $messages, $customAttributes, $selector);
-
-        $this->assertInstanceOf(\Proengsoft\JsValidation\Javascript\JavascriptValidator::class, $jsValidator);
+        $jsValidator = $this->app['jsvalidator']->make($rules, $messages, $customAttributes, $data);
+        $this->assertEquals([
+            "name[*]" => [
+                "laravelValidation" => [
+                    [
+                        "Required",
+                        [],
+                        "The Name field is required.",
+                        true
+                    ]
+                ]
+            ],
+            "name[key0]" => [
+                "laravelValidation" => [
+                    [
+                        "Required",
+                        [],
+                        "The Name Key 0 field is required.",
+                        true
+                    ]
+                ]
+            ]
+        ], $jsValidator->toArray()['rules']);
     }
 
     public function testMakeWithToken()


### PR DESCRIPTION
### Description

Laravel validation converts `*` to `__asterisk__` in Laravel 6+ (https://github.com/laravel/framework/pull/31257).

helpers.js relies on `[*]` to parse those wildcard rules:
```js
regexFromWildcard: function(name) {
      var nameParts = name.split("[*]");
```

Todo:
- [x] Find a solution for Laravel 5.6 - 5.8 or bump the minimum version to 6.0+
- [x] Add tests