### PR TITLE
Fixes #424

### DIFF
--- a/config/jsvalidation.php
+++ b/config/jsvalidation.php
@@ -43,4 +43,11 @@ return [
      * Whether to escape all validation messages with htmlentities.
      */
     'escape' => false,
+
+    /*
+     * Set a default value for the validate ignore property.
+     *
+     * See https://jqueryvalidation.org/validate/#ignore
+     */
+    'ignore' => ":hidden, [contenteditable='true']"
 ];

--- a/src/Javascript/JavascriptValidator.php
+++ b/src/Javascript/JavascriptValidator.php
@@ -12,7 +12,7 @@ class JavascriptValidator implements Arrayable
     /**
      * Registered validator instance.
      *
-     * @var \Proengsoft\JsValidation\Javascript\ValidatorHandler
+     * @var ValidatorHandler
      */
     protected $validator;
 
@@ -45,8 +45,10 @@ class JavascriptValidator implements Arrayable
     protected $ignore;
 
     /**
-     * @param \Proengsoft\JsValidation\Javascript\ValidatorHandler $validator
-     * @param array $options
+     * Constructor.
+     *
+     * @param ValidatorHandler $validator
+     * @param array            $options
      */
     public function __construct(ValidatorHandler $validator, $options = [])
     {
@@ -65,6 +67,10 @@ class JavascriptValidator implements Arrayable
         $this->selector = empty($options['selector']) ? 'form' : $options['selector'];
         $this->view = empty($options['view']) ? 'jsvalidation::bootstrap' : $options['view'];
         $this->remote = isset($options['remote']) ? $options['remote'] : true;
+
+        if (isset($options['ignore'])) {
+            $this->ignore = $options['ignore'];
+        }
     }
 
     /**

--- a/src/JsValidatorFactory.php
+++ b/src/JsValidatorFactory.php
@@ -207,6 +207,7 @@ class JsValidatorFactory
         $remote = ! $this->options['disable_remote_validation'];
         $view = $this->options['view'];
         $selector = is_null($selector) ? $this->options['form_selector'] : $selector;
+        $ignore = $this->options['ignore'];
 
         $delegated = new DelegatedValidator($validator, new ValidationRuleParserProxy($validator->getData()));
         $rules = new RuleParser($delegated, $this->getSessionToken());
@@ -214,7 +215,7 @@ class JsValidatorFactory
 
         $jsValidator = new ValidatorHandler($rules, $messages);
 
-        $manager = new JavascriptValidator($jsValidator, compact('view', 'selector', 'remote'));
+        $manager = new JavascriptValidator($jsValidator, compact('view', 'selector', 'remote', 'ignore'));
 
         return $manager;
     }

--- a/tests/Javascript/JavascriptValidatorTest.php
+++ b/tests/Javascript/JavascriptValidatorTest.php
@@ -170,6 +170,47 @@ class JavascriptValidatorTest extends TestCase
         $this->assertEquals($expected,$viewData);
     }
 
+    /**
+     * Test the default ignore parameter value.
+     *
+     * @return void
+     */
+    public function testIgnoreDefault()
+    {
+        $jsValidator = $this->app['jsvalidator']->make([]);
+
+        $this->assertArrayHasKey('ignore', $jsValidator->toArray());
+        $this->assertEquals(":hidden, [contenteditable='true']", $jsValidator->toArray()['ignore']);
+    }
+
+    /**
+     * Test a custom ignore parameter value.
+     *
+     * @return void
+     */
+    public function testIgnoreCustom()
+    {
+        $this->app['config']->set('jsvalidation.ignore', ':hidden');
+        $jsValidator = $this->app['jsvalidator']->make([]);
+
+        $this->assertArrayHasKey('ignore', $jsValidator->toArray());
+        $this->assertEquals(":hidden", $jsValidator->toArray()['ignore']);
+    }
+
+    /**
+     * Test a custom ignore parameter value.
+     *
+     * @return void
+     */
+    public function testIgnoreCustom2()
+    {
+        $jsValidator = $this->app['jsvalidator']->make([]);
+        $jsValidator->ignore(':hidden');
+
+        $this->assertArrayHasKey('ignore', $jsValidator->toArray());
+        $this->assertEquals(":hidden", $jsValidator->toArray()['ignore']);
+    }
+
     public function testRemote()
     {
         $remote = true;

--- a/tests/JsValidatorFactoryTest.php
+++ b/tests/JsValidatorFactoryTest.php
@@ -60,6 +60,7 @@ class JsValidatorFactoryTest extends TestCase
             ->with('encrypter')
             ->willReturn(null);
 
+        $options = $this->app['config']->get('jsvalidation');
         $options['disable_remote_validation'] = false;
         $options['view'] = 'jsvalidation::bootstrap';
         $options['form_selector'] = 'form';
@@ -91,6 +92,7 @@ class JsValidatorFactoryTest extends TestCase
             ->with('encrypter')
             ->willReturn(null);
 
+        $options = $this->app['config']->get('jsvalidation');
         $options['disable_remote_validation'] = false;
         $options['view'] = 'jsvalidation::bootstrap';
         $options['form_selector'] = 'form';
@@ -123,6 +125,7 @@ class JsValidatorFactoryTest extends TestCase
             ->with('encrypter')
             ->willReturn(null);
 
+        $options = $this->app['config']->get('jsvalidation');
         $options['disable_remote_validation'] = false;
         $options['view'] = 'jsvalidation::bootstrap';
         $options['form_selector'] = 'form';
@@ -168,6 +171,7 @@ class JsValidatorFactoryTest extends TestCase
             ->with('encrypter')
             ->willReturn($encrypterMock);
 
+        $options = $this->app['config']->get('jsvalidation');
         $options['disable_remote_validation'] = false;
         $options['view'] = 'jsvalidation::bootstrap';
         $options['form_selector'] = 'form';
@@ -186,6 +190,7 @@ class JsValidatorFactoryTest extends TestCase
         $customAttributes = [];
         $selector = null;
 
+        $options = $this->app['config']->get('jsvalidation');
         $options['disable_remote_validation'] = false;
         $options['view'] = 'jsvalidation::bootstrap';
         $options['form_selector'] = 'form';
@@ -214,6 +219,7 @@ class JsValidatorFactoryTest extends TestCase
         $customAttributes = [];
         $selector = null;
 
+        $options = $this->app['config']->get('jsvalidation');
         $options['disable_remote_validation'] = false;
         $options['view'] = 'jsvalidation::bootstrap';
         $options['form_selector'] = 'form';


### PR DESCRIPTION
### Description

Added a config option to set a default `ignore` value (https://jqueryvalidation.org/validate/#ignore)

Defaults to disabling contentEditable as this is how the package has always worked and there's a bug upstream in the way it handles elements with no name / id. See issue for more information this point.
