### PR TITLE
Fixed style ci config

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,9 +1,6 @@
 preset: laravel
 
-risky: true
-
 enabled:
-  - strict
   - unalign_double_arrow
 
 disabled:

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,11 +1,15 @@
 preset: laravel
 
+risky: true
+
 enabled:
+  - strict
   - unalign_double_arrow
 
 disabled:
   - concat_without_spaces
   - phpdoc_no_package
+  - no_alternative_syntax
 
 finder:
   exclude:

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -7,7 +7,6 @@ enabled:
 disabled:
   - concat_without_spaces
   - phpdoc_no_package
-  - simplified_null_return
 
 finder:
   exclude:

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,5 +1,7 @@
 preset: laravel
 
+risky: true
+
 enabled:
   - strict
   - unalign_double_arrow


### PR DESCRIPTION
### Description

Fixed The 'simplified_null_return' fixer cannot be disabled because it is not enabled by your preset.
