### PR TITLE
Update composer-8.0.json

### DIFF
--- a/tests/composer-8.0.json
+++ b/tests/composer-8.0.json
@@ -11,7 +11,7 @@
         "symfony/http-foundation": "^5.0"
     },
     "require-dev": {
-        "orchestra/testbench": "dev-master",
+        "orchestra/testbench": "dev-6.x",
         "phpunit/phpunit": "^8.0",
         "mockery/mockery": "^1.0"
     },

--- a/tests/composer-8.0.json
+++ b/tests/composer-8.0.json
@@ -11,7 +11,7 @@
         "symfony/http-foundation": "^5.0"
     },
     "require-dev": {
-        "orchestra/testbench": "dev-6.x",
+        "orchestra/testbench": "6.x-dev",
         "phpunit/phpunit": "^8.0",
         "mockery/mockery": "^1.0"
     },


### PR DESCRIPTION
```
export COMPOSER=tests/composer-8.0.json && composer install --no-interaction --prefer-source
  shell: /bin/bash -e {0}
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for illuminate/support ^8.0 -> satisfiable by illuminate/support[8.x-dev].
    - orchestra/testbench dev-master requires laravel/framework dev-master -> satisfiable by laravel/framework[dev-master].
    - don't install laravel/framework dev-master|don't install illuminate/support 8.x-dev
    - Installation request for orchestra/testbench dev-master -> satisfiable by orchestra/testbench[dev-master].
```