### PR TITLE
Add Laravel 8 to supported versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can validate forms automatically referencing it to your defined validations.
 
 #### Supported versions
 
-Laravel 5.6 - 7.x
+Laravel 5.6 - 8.x
 
 #### Feature overview
 


### PR DESCRIPTION
I was looking at the docs and noticed it doesn't say Laravel 8 is supported, even though Laravel 8 support was added in version [4.1.0](https://github.com/proengsoft/laravel-jsvalidation/releases/tag/4.1.0).