### PR TITLE
ci: stop testing on Laravel 5 releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        laravel: ['5.6', '5.7', '5.8', '6.0', '7.0', '8.0']
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        laravel: ['6.0', '7.0', '8.0']
+        php: ['7.2', '7.3', '7.4', '8.0']
         exclude:
-          - {laravel: '5.6', php: '7.4'}
-          - {laravel: '5.6', php: '8.0'}
-          - {laravel: '5.7', php: '7.4'}
-          - {laravel: '5.7', php: '8.0'}
-          - {laravel: '5.8', php: '8.0'}
           - {laravel: '6.0', php: '7.1'}
           - {laravel: '7.0', php: '7.1'}
           - {laravel: '8.0', php: '7.1'}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can validate forms automatically referencing it to your defined validations.
 
 #### Supported versions
 
-Laravel 5.6 - 8.x
+Laravel 6.x - 8.x
 
 #### Feature overview
 


### PR DESCRIPTION
### Description

No changes to source code, but dropping support for Laravel 5 releases. Testing against so any versions is burdensome.
