### PR TITLE
ci: remove xdebug from tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,10 +33,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
 
       - name: Install dependencies
         run: export COMPOSER=tests/composer-${{ matrix.laravel }}.json && composer install --no-interaction --prefer-source
 
       - name: Execute tests
-        run: vendor/bin/phpunit --coverage-text
+        run: vendor/bin/phpunit


### PR DESCRIPTION
### Description

What does this achieve?

XDebug is not necessary and slows down the tests - the code coverage workflow is separate.
