### PR TITLE
fix: min / max array rules

### DIFF
--- a/resources/assets/js/helpers.js
+++ b/resources/assets/js/helpers.js
@@ -526,7 +526,7 @@ $.extend(true, laravelValidation, {
          * @returns {*|string}
          */
         allElementValues: function (validator, element) {
-            if (element.name.indexOf('[') !== -1 && element.name.indexOf(']') !== -1) {
+            if (element.name.indexOf('[]') !== -1) {
                 return validator.findByName(element.name).map(function (i, e) {
                     return validator.elementValue(e);
                 }).get();


### PR DESCRIPTION
Added fix for issue #631

### Description

Fixes a problem introduced in 4.4.3 (Min and Max validation rules stopped working for arrays with keys as per issue #631) that was designed to address issue #613. 

The function `allElementValues` now looks for an empty array pattern in the string rather than the individual brackets.
