### PR TITLE
ci: cache composer dependencies

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -24,6 +24,18 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
 
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
       - name: Install dependencies
         run: export COMPOSER=tests/composer-${{ matrix.laravel }}.json && composer install --no-interaction --prefer-source
 


### PR DESCRIPTION
### Description

What does this achieve?

https://github.com/actions/cache/blob/main/examples.md#php---composer

Is it necessary to merge into core or can it be overridden using existing features?
