### PR TITLE
fix: date format rules

### DIFF
--- a/resources/assets/js/helpers.js
+++ b/resources/assets/js/helpers.js
@@ -200,8 +200,10 @@ $.extend(true, laravelValidation, {
                 timeValue = this.strtotime(value);
             } else {
                 timeValue = fmt.parseDate(value, format);
-                if (timeValue) {
+                if (timeValue instanceof Date && fmt.formatDate(timeValue, format) === value) {
                     timeValue = Math.round((timeValue.getTime() / 1000));
+                } else {
+                    timeValue = false;
                 }
             }
 


### PR DESCRIPTION
Fixes #851 

### Description

This fixes a bug in date format rules.

Since kartik-v/php-date-formatter v1.3.4, `DateFormatter.parseDate()` returns `null` instead of `false` when input does not match expected format. This resulted in laravel-jsvalidation `DateFormat` rules always succeeding.

With this change, helper `parseTime()`:
- performs the same checks as Laravel `date_format` rule: try to parse input value, then format it back and compare the result with original input value
- returns `false` as it should when input does not match the expected date format
