### PR TITLE
Fixed dependentElement when there are multiple elements with the same…

### DIFF
--- a/resources/assets/js/helpers.js
+++ b/resources/assets/js/helpers.js
@@ -348,28 +348,31 @@ $.extend(true, laravelValidation, {
          * @returns {*}
          */
         dependentElement: function(validator, element, name) {
-
-            var el=validator.findByName(name);
-
-            if ( el[0]!==undefined  && validator.settings.onfocusout ) {
+            var el = validator.findByName(name);
+            
+            var targetElement = el[el.length - 1];
+    
+            if (targetElement !== undefined && validator.settings.onfocusout) {
                 var event = 'blur';
-                if (el[0].tagName === 'SELECT' ||
-                    el[0].tagName === 'OPTION' ||
-                    el[0].type === 'checkbox' ||
-                    el[0].type === 'radio'
+                if (
+                    targetElement.tagName === 'SELECT' ||
+                    targetElement.tagName === 'OPTION' ||
+                    targetElement.type === 'checkbox' ||
+                    targetElement.type === 'radio'
                 ) {
                     event = 'click';
                 }
-
+    
                 var ruleName = '.validate-laravelValidation';
-                el.off( ruleName )
+                $(targetElement)
+                    .off(ruleName)
                     .off(event + ruleName + '-' + element.name)
-                    .on( event + ruleName + '-' + element.name, function() {
-                        $( element ).valid();
+                    .on(event + ruleName + '-' + element.name, function () {
+                        $(element).valid();
                     });
             }
-
-            return el[0];
+    
+            return targetElement;
         },
 
         /**


### PR DESCRIPTION
**What does this achieve?**

This change ensures that the last input element with a given name is used when evaluating dependencies in custom validation logic.

This is important because, in HTML form submissions, the last matching input with the same name takes precedence when there are multiple inputs with the same name. A common example is when using a hidden input alongside a checkbox to provide a default value:

```html
<input type="hidden" name="my_checkbox" value="0">
<input type="checkbox" name="my_checkbox" value="1">
```

This pattern is widely used to ensure a consistent value is submitted whether the checkbox is checked or not. If the checkbox is unchecked, only the hidden input (value="0") is submitted. If it is checked, both are submitted, but the checkbox value (1) takes precedence.

Without this fix, the validation logic incorrectly evaluates the first input (the hidden one), ignoring the actual user interaction with the checkbox. By using the last matching input, we align the validation behavior with how browsers and backends (like Laravel) interpret the submitted data.